### PR TITLE
FIXED value type property values passed to nongeneric delegates are boxed properly before call and unboxed after return

### DIFF
--- a/Afterthought.UnitTest.Target/Calculator.cs
+++ b/Afterthought.UnitTest.Target/Calculator.cs
@@ -345,5 +345,19 @@ namespace Afterthought.UnitTest.Target
 		}
 
 		public event EventHandler Calculate;
+
+	    public object ValueTypePropertyAfterGetValue = 0;
+	    public object ValueTypePropertyBeforeSetOldValue = 0;
+	    public object ValueTypePropertyBeforeSetValue = 0;
+	    public object ValueTypePropertyAfterSetOldValue = 0;
+	    public object ValueTypePropertyAfterSetValue = 0;
+	    public object ValueTypePropertyAfterSetNewValue = 0;
+	    public int _valueTypeProperty;
+
+	    public int ValueTypeProperty
+	    {
+	        get { return _valueTypeProperty; }
+	        set { _valueTypeProperty = value + 1; }
+	    }
 	}
 }

--- a/Afterthought.UnitTest.Target/TestAmendment.cs
+++ b/Afterthought.UnitTest.Target/TestAmendment.cs
@@ -281,6 +281,23 @@ namespace Afterthought.UnitTest.Target
 				.OfType<string>()
 				.LazyInitialize((instance, propertyName) => "r" + new Random().Next());
 
+		    Properties
+		        .Named("ValueTypeProperty")
+		        .AfterGet((instance, propertyName, value) =>
+                    instance.ValueTypePropertyAfterGetValue = value)
+		        .BeforeSet((instance, propertyName, oldValue, value) =>
+		        {
+		            instance.ValueTypePropertyBeforeSetOldValue = oldValue;
+		            instance.ValueTypePropertyBeforeSetValue = value;
+		            return value;
+		        })
+		        .AfterSet((instance, propertyName, oldValue, value, newValue) =>
+		        {
+		            instance.ValueTypePropertyAfterSetOldValue = oldValue;
+		            instance.ValueTypePropertyAfterSetValue = value;
+		            instance.ValueTypePropertyAfterSetNewValue = newValue;
+		        });
+
 			#endregion
 
 			#region Interfaces

--- a/Afterthought.UnitTest/PropertyTests.cs
+++ b/Afterthought.UnitTest/PropertyTests.cs
@@ -308,5 +308,28 @@ namespace Afterthought.UnitTest
 		public void BeforeSetWithOriginalAndNewValue()
 		{
 		}
+
+	    /// <summary>
+	    /// Tests amending code to pass ValueType property value to the nongeneric
+	    /// AfterGet, BeforeSet and AfterSet delegates with object parameters (with boxing)
+	    /// </summary>
+	    [TestMethod]
+	    public void AfterAndBeforeValueTypePropertyGetAndSetAmendedThroughNotTypedDelegate()
+	    {
+	        Calculator._valueTypeProperty = 5;
+
+	        Calculator.ValueTypeProperty.ToString();
+
+            Assert.AreEqual(Calculator.ValueTypePropertyAfterGetValue, 5);
+
+	        Calculator.ValueTypeProperty = 10;
+
+	        Assert.AreEqual(Calculator.ValueTypePropertyBeforeSetOldValue, 5);
+	        Assert.AreEqual(Calculator.ValueTypePropertyBeforeSetValue, 10);
+
+	        Assert.AreEqual(Calculator.ValueTypePropertyAfterSetOldValue, 5);
+	        Assert.AreEqual(Calculator.ValueTypePropertyAfterSetValue, 10);
+	        Assert.AreEqual(Calculator.ValueTypePropertyAfterSetNewValue, 11);
+	    }
 	}
 }


### PR DESCRIPTION
Nongeneric property amendments delegates (with object typed parameters) do not work with ValueType properties because the emitted code does not box and unbox them properly.
I fixed that by emitting box operations for parameters passed to delegates if property type is ValueType and delegate's parameter is Object. Same with return values,
Test which does not work without fix is applied.